### PR TITLE
Fix generators not respecting headers

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -143,6 +143,9 @@ const handleStream = (
 	const readable = new Readable({
 		read() {}
 	})
+	if (res) {
+		readable.pipe(res)
+	}
 	;(async () => {
 		let init = generator.next()
 		if (init instanceof Promise) init = await init
@@ -156,7 +159,9 @@ const handleStream = (
 			}
 		else {
 			set.headers['transfer-encoding'] = 'chunked'
-			set.headers['content-type'] = 'text/event-stream;charset=utf8'
+			if (!set.headers['content-type']) {
+				set.headers['content-type'] = 'text/event-stream;charset=utf8'
+			}
 		}
 	
 		if (res) res.writeHead(set.status as number, set.headers)

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,7 +410,7 @@ export const node = () => {
 										// @ts-expect-error private property
 										app._handle
 									).listen(
-										typeof options === 'number'
+										typeof options === 'number' || typeof options === "string"
 											? options
 											: {
 													...options,

--- a/test/core/generators.test.ts
+++ b/test/core/generators.test.ts
@@ -1,0 +1,65 @@
+import Elysia from 'elysia'
+import { inject } from 'light-my-request'
+import { describe, it, expect } from 'vitest'
+
+import node from '../../src'
+
+function delay(n: number) {
+    return new Promise((resolve)=>{
+        setTimeout(()=>{
+            resolve(null)
+        }, n)
+    })
+}
+
+const app =  new Elysia({ adapter: node() })
+    .get("/what", ()=>"feafe")
+    .get('/', function* gen({set}) {
+        set.headers["content-type"] = "application/json"
+        set.headers["content-disposition"] = 'attachment; filename="test.json"'
+        yield JSON.stringify({x: "hi"})
+    })
+    .get('/async-simple', async function* gen({set}) {
+        set.headers["content-type"] = "application/json"
+        set.headers["content-disposition"] = 'attachment; filename="test.json"'
+        await delay(100)
+        yield JSON.stringify({x: "hi"})
+    })
+    .get('/async-hard', async function* gen({set}) {
+        await delay(100)
+        set.headers["content-type"] = "application/json"
+        set.headers["content-disposition"] = 'attachment; filename="test.json"'
+        await delay(100)
+        yield JSON.stringify({x: "hi"})
+    })
+    .compile()
+
+
+// @ts-expect-error
+const handle = app._handle!
+
+describe("Async generators", ()=>{
+
+    it("handle /", async ()=>{
+        await inject(handle, { path: "/"}, (error, res)=>{
+            console.log(res)
+            expect(res?.headers["content-type"]).toBe("application/json")
+            expect(res?.headers["content-disposition"]).toBe('attachment; filename="test.json"')
+        })
+    })
+
+    it("handle /async-simple", async ()=>{
+        await inject(handle, { path: "/async-simple"}, (error, res)=>{
+            expect(true).toBe(false)
+            expect(res?.headers["content-type"]).toBe("application/json")
+            expect(res?.headers["content-disposition"]).toBe('attachment; filename="test.json"')
+        })
+    })
+
+    it("handle /async-hard", async ()=>{
+        await inject(handle, { path: "/async-hard"}, (error, res)=>{
+            expect(res?.headers["content-type"]).toBe("application/json")
+            expect(res?.headers["content-disposition"]).toBe('attachment; filename="test.json"')
+        })
+    })
+})


### PR DESCRIPTION
```typescript
import { Elysia } from 'elysia'
import { node } from '@elysiajs/node'

new Elysia({ adapter: node() })
	.get('/', function*({set}) {
		set.headers["content-type"] = "application/jsonl"
		set.headers["content-disposition"] = 'attachment; filename="export.jsonl"'
		for (let i = 0; i <100; i++) {
			yield JSON.stringify({i})+"\n"
		}
	})
	.listen(3000)
```

This would ignore the set headers because it isn't defined until the first generator.next() call I think. This fixes that bug and adds some test cases for it



