### PR TITLE
fix: incorrectly constructed responses for 204 status codes

### DIFF
--- a/src/handle.ts
+++ b/src/handle.ts
@@ -115,7 +115,7 @@ export const mapResponse = (
 				return new Response(response as ReadableStream, set as any)
 
 			case undefined:
-				if (!response) return new Response('', set as any)
+				if (!response) return new Response(null, set as any)
 
 				return new Response(JSON.stringify(response), set as any)
 


### PR DESCRIPTION
When returning `status(204)` or `status(204, null)`, the actual response gets constructed with an empty string instead of `null`. This throws an error in a variety of environments/runtimes (e.g. Vercel/Cloudflare). Instead we should construct the response passing in `null` as first param.  


Fixes https://github.com/elysiajs/elysia/issues/1277 for the node adapter

## Vercel Error

<img width="1559" height="207" alt="Screenshot 2025-10-29 at 15 28 48" src="https://github.com/user-attachments/assets/d59a0eae-d21e-4b4c-a834-699445743e4a" />

## Cloudflare Error

> Constructing a Response with a null body status (204) and a non-null, zero-length body. This is technically incorrect, and we recommend you update your code to explicitly pass in a null body, e.g. new Response(null, { status: 204, ... }). (We continue to allow the zero-length body behavior because it was previously the only way to construct a Response with a null body status. This behavior may change in the future.)


I tested that this fixes the issue by deploying our app with a forked version of `@elysiajs/node`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected response handling to properly return null for undefined responses instead of empty strings, ensuring consistent behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->