### PR TITLE
fix: preserve multiple set-cookie headers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,35 +99,43 @@ export function mergeHeaders(
 		headers.append(key, value)
 	}
 
-	for (const cookie of responseHeaders.getSetCookie())
+	for (const cookie of responseHeaders.getSetCookie()) {
 		headers.append('set-cookie', cookie)
+	}
 
 	// Merge headers: Response headers take precedence, set.headers fill in non-conflicting ones
-	if (setHeaders instanceof Headers)
+	if (setHeaders instanceof Headers) {
 		// @ts-ignore
 		for (const key of setHeaders.keys()) {
 			if (key === 'set-cookie') {
 				if (headers.has('set-cookie')) continue
 
-				for (const cookie of setHeaders.getSetCookie())
+				for (const cookie of setHeaders.getSetCookie()) {
 					headers.append('set-cookie', cookie)
-			} else if (!responseHeaders.has(key))
+				}
+			} else if (!responseHeaders.has(key)) {
 				headers.set(key, setHeaders?.get(key) ?? '')
+			}
 		}
-	else
-		for (const key in setHeaders)
+	} else {
+		for (const key in setHeaders) {
 			if (key === 'set-cookie') {
 				if (headers.has('set-cookie')) continue
 
 				const cookies = setHeaders[key]
 
-				if (Array.isArray(cookies))
-					for (const cookie of cookies)
+				if (Array.isArray(cookies)) {
+					for (const cookie of cookies) {
 						headers.append('set-cookie', cookie)
-				else headers.append('set-cookie', cookies as string)
-			}
-			else if (!responseHeaders.has(key))
+					}
+				} else {
+					headers.append('set-cookie', cookies as string)
+				}
+			} else if (!responseHeaders.has(key)) {
 				headers.set(key, setHeaders[key] as any)
+			}
+		}
+	}
 
 	return headers
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,8 +92,15 @@ export function mergeHeaders(
 	responseHeaders: Headers,
 	setHeaders: Context['set']['headers']
 ) {
-	// @ts-ignore
-	const headers = new Headers(Object.fromEntries(responseHeaders.entries()))
+	const headers = new Headers()
+
+	for (const [key, value] of responseHeaders.entries()) {
+		if (key === 'set-cookie') continue
+		headers.append(key, value)
+	}
+
+	for (const cookie of responseHeaders.getSetCookie())
+		headers.append('set-cookie', cookie)
 
 	// Merge headers: Response headers take precedence, set.headers fill in non-conflicting ones
 	if (setHeaders instanceof Headers)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,8 +116,16 @@ export function mergeHeaders(
 		}
 	else
 		for (const key in setHeaders)
-			if (key === 'set-cookie')
-				headers.append(key, setHeaders[key] as any)
+			if (key === 'set-cookie') {
+				if (headers.has('set-cookie')) continue
+
+				const cookies = setHeaders[key]
+
+				if (Array.isArray(cookies))
+					for (const cookie of cookies)
+						headers.append('set-cookie', cookie)
+				else headers.append('set-cookie', cookies as string)
+			}
 			else if (!responseHeaders.has(key))
 				headers.set(key, setHeaders[key] as any)
 


### PR DESCRIPTION
## Problem

The Node adapter rebuilds `responseHeaders` with:

```ts
new Headers(Object.fromEntries(responseHeaders.entries()))
```

This collapses duplicate header names, which is especially problematic for `Set-Cookie`.

In OAuth callback flows, downstream handlers can return multiple `Set-Cookie` headers.
On Bun this worked, but on the Node adapter one of the cookies could be dropped during header merging.

In my reproduction this broke Better Auth on the OAuth callback route:
- the callback returned with `code` and `state`
- the state cookie was present
- the session cookie was lost before later API requests

## Fix

Preserve multiple `Set-Cookie` headers when merging response headers.

## Related

This looks related to elysiajs/elysia#1547, which reports another `Set-Cookie` loss path in Elysia.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves all cookies when merging response headers so multiple cookies are no longer lost.
  * Accepts multiple cookie values when cookies are supplied as arrays, appending each cookie.
  * Avoids duplicating cookies if already present and no longer overwrites existing non-cookie headers during merges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/node/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->